### PR TITLE
Fix bug in GCC's target platform detection under some non-English locales

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -70,7 +70,7 @@ VERBOSE ?= NO
 ################################################################################
 
 CC ?= gcc
-TARGETPLATFORM := $(shell LANG=en_US.UTF-8 $(CC) -v 2>&1 | grep '^Target: ' | cut -f 2 -d ' ')
+TARGETPLATFORM := $(shell LANG=en_US.UTF-8 LANGUAGE=en_US $(CC) -v 2>&1 | grep '^Target: ' | cut -f 2 -d ' ')
 
 ifneq (,$(findstring darwin,$(TARGETPLATFORM)))
   DARWIN := 1


### PR DESCRIPTION
According to GNU gettext's [documention](https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html), the environment variable `LANGUAGE` will be considered in priority than `LANG` when GNU gettext tries to get locale-dependent contents. Therefore, for an environment where `LANGUAGE` is set to some value other than English(e.g. `zh_CN`), only specifying `LANG` to be `en_US.UTF-8` is not enough to let GCC output English contents thus `TARGETPLATFORM` would be unable to be obtained and eventually a build error would occur. This PR is intended to fix this problem.