### PR TITLE
docs: fix simple typo, routeable -> routable

### DIFF
--- a/src/msrpc-server.c
+++ b/src/msrpc-server.c
@@ -184,10 +184,10 @@ static int_fast8_t IsPrivateIPAddress(char* ipAddress)
 			if
 			(
 				(ip & 0xff000000) == 0x7f000000 || // 127.x.x.x localhost
-				(ip & 0xffff0000) == 0xc0a80000 || // 192.168.x.x private routeable
+				(ip & 0xffff0000) == 0xc0a80000 || // 192.168.x.x private routable
 				(ip & 0xffff0000) == 0xa9fe0000 || // 169.254.x.x link local
-				(ip & 0xff000000) == 0x0a000000 || // 10.x.x.x private routeable
-				(ip & 0xfff00000) == 0xac100000    // 172.16-31.x.x private routeable
+				(ip & 0xff000000) == 0x0a000000 || // 10.x.x.x private routable
+				(ip & 0xfff00000) == 0xac100000    // 172.16-31.x.x private routable
 			)
 			{
 				return TRUE;

--- a/src/network.c
+++ b/src/network.c
@@ -205,10 +205,10 @@ static int_fast8_t isPrivateIPAddress(struct sockaddr* addr, socklen_t* length)
 		if
 			(
 			(ipv4addr & 0xff000000) != 0x7f000000 && // 127.x.x.x localhost
-				(ipv4addr & 0xffff0000) != 0xc0a80000 && // 192.168.x.x private routeable
+				(ipv4addr & 0xffff0000) != 0xc0a80000 && // 192.168.x.x private routable
 				(ipv4addr & 0xffff0000) != 0xa9fe0000 && // 169.254.x.x link local
-				(ipv4addr & 0xff000000) != 0x0a000000 && // 10.x.x.x private routeable
-				(ipv4addr & 0xfff00000) != 0xac100000    // 172.16-31.x.x private routeable
+				(ipv4addr & 0xff000000) != 0x0a000000 && // 10.x.x.x private routable
+				(ipv4addr & 0xfff00000) != 0xac100000    // 172.16-31.x.x private routable
 				)
 		{
 			return FALSE;


### PR DESCRIPTION
There is a small typo in src/msrpc-server.c, src/network.c.

Should read `routable` rather than `routeable`.

