### PR TITLE
building from scrach in OpenBSD

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -126,6 +126,7 @@ ifneq (,$(findstring openbsd,$(TARGETPLATFORM)))
   UNIX := 1
   BSD := 1
   ELF := 1
+  THREADS := 1
 endif
 
 ifneq (,$(findstring solaris,$(TARGETPLATFORM)))


### PR DESCRIPTION
when building from scrach in OpenBSD use threads instead of fork because of missing pthread_mutexattr_setpshared