### PR TITLE
also search for root\\tap0901 ComponentId for vpn tap adapter

### DIFF
--- a/src/wintap.c
+++ b/src/wintap.c
@@ -188,6 +188,7 @@ static HANDLE OpenTapHandle()
 					(
 						!strncmp(regData, "tap0801", sizeof(regData)) ||
 						!strncmp(regData, "tap0901", sizeof(regData)) ||
+						!strncmp(regData, "root\\tap0901", sizeof(regData)) ||
 						!strncmp(regData, "TEAMVIEWERVPN", sizeof(regData))
 						)
 					)


### PR DESCRIPTION
When using the "TAP-Windows Adapter V9" from OpenVPN 2.6.6 on Windows 10, the ComponentId is actually `root\tap0901`, rather than `tap0901`. Add this to the search criteria in wintap.c.

([Here's](https://github.com/OpenVPN/tap-windows6/commit/a9fb4a329e75a4f5366167800148468373c37a91) the tap-windows6 update that we're working around)